### PR TITLE
Fix wrong link for the "bin-server" project

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
                             discord) existent sur l'orga.
                         </p>
                         <ul class="links">
-                            <li><a href="https://github.com/readthedocs-fr/notions">Dépôt GitHub</a></li>
+                            <li><a href="https://github.com/readthedocs-fr/bin-server">Dépôt GitHub</a></li>
                         </ul>
                     </article>
                     <article class="card">


### PR DESCRIPTION
The project card for "bin-server" had a link redirecting to the wrong github repository.
```html
<li><a href="https://github.com/readthedocs-fr/notions">Dépôt GitHub</a></li>
```
Changed to :
```html
<li><a href="https://github.com/readthedocs-fr/bin-server">Dépôt GitHub</a></li>
```